### PR TITLE
Better Readme + unified addEventListener

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 [![Build status](https://travis-ci.org/Scrivito/scroll-to-fragment.svg?branch=master)](https://travis-ci.org/github/Scrivito/scroll-to-fragment)
 [![Package size](https://badgen.net/bundlephobia/minzip/scroll-to-fragment)](https://bundlephobia.com/result?p=scroll-to-fragment)
+[![NPM Version](https://badgen.net/npm/v/scroll-to-fragment)](https://www.npmjs.com/package/scroll-to-fragment)
+[![Types included](https://badgen.net/npm/types/scroll-to-fragment)](https://www.npmjs.com/package/scroll-to-fragment)
 [![Supported by Scrivito](https://badgen.net/badge/%E2%99%A5%20supported%20by/Scrivito/1BAE61)](https://www.scrivito.com/?utm_source=npm&utm_medium=natural&utm_campaign=scroll-to-fragment)
 
 Make single page apps scroll to the current URL hash.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "scroll-to-fragment",
-  "version": "1.0.0",
+  "version": "1.0.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -41,5 +41,5 @@
     "test": "karma start --single-run",
     "watch": "karma start"
   },
-  "version": "1.0.5"
+  "version": "1.0.6"
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -37,8 +37,8 @@ function startObserving() {
   stopObserving();
   if (!location.hash) return;
 
-  addEventListener("touchend", stopObserving);
-  addEventListener("wheel", stopObserving);
+  document.addEventListener("touchend", stopObserving);
+  document.addEventListener("wheel", stopObserving);
   document.addEventListener("selectstart", stopObserving);
   documentObserver?.observe(document, OBSERVER_CONFIG);
   adjustScrollPosition();
@@ -50,8 +50,8 @@ function stopObserving() {
   clearTimeout(observeTimeout);
   cancelAnimationFrame(throttleRequestId);
   documentObserver?.disconnect();
-  removeEventListener("touchend", stopObserving);
-  removeEventListener("wheel", stopObserving);
+  document.removeEventListener("touchend", stopObserving);
+  document.removeEventListener("wheel", stopObserving);
   document.removeEventListener("selectionchange", stopObserving);
 }
 


### PR DESCRIPTION
* ~~Always throttle `startObserving` and `adjustScrollPosition` independently.~~
* Improved readme.
* Unified usage of addEventListener and removeEventListener.

~~Diff best viewed without whitespace changes.~~